### PR TITLE
Evaluated entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^27.0.5",
-    "@proc7ts/context-values": "^7.0.0-dev.2",
+    "@proc7ts/context-values": "^7.0.0-dev.3",
     "@proc7ts/fun-events": "^10.5.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@run-z/eslint-config": "^1.3.0",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -55,17 +55,18 @@ export class CxBuilder<TContext extends CxValues = CxValues>
   /**
    * Constructs context builder.
    *
-   * @param createContext - Context creator function. Accepts context value getter as its only parameter and returns
-   * created context.
+   * @param createContext - Context creator function. Accepts context value {@link CxValues.Getter getter} and the
+   * builder itself as parameters, and returns created context.
    * @param initial - Initial context value assets provider. These assets applies before the ones provided
    * {@link provide explicitly}.
    */
   constructor(
-      createContext: (this: void, getValue: CxValues.Getter) => TContext,
+      createContext: (this: void, getValue: CxValues.Getter, builder: CxBuilder<TContext>) => TContext,
       initial: CxBuilder.AssetSource = CxBuilder$noAssets,
   ) {
     this._cx = lazyValue(() => createContext(
         (entry, request) => this.get(entry, request),
+        this,
     ));
     this._initial = initial;
   }

--- a/src/entries/evaluated.entry.spec.ts
+++ b/src/entries/evaluated.entry.spec.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { cxEvaluated, CxReferenceError, CxValues } from '@proc7ts/context-values';
+import { cxConstAsset } from '../assets';
+import { CxBuilder } from '../builder';
+
+describe('cxArray', () => {
+
+  let builder: CxBuilder;
+  let context: CxValues;
+
+  beforeEach(() => {
+    builder = new CxBuilder(get => ({ get }));
+    context = builder.context;
+  });
+
+  it('provides nothing by default', () => {
+
+    const entry = { perContext: cxEvaluated<string>(() => null) };
+
+    expect(() => context.get(entry)).toThrow(new CxReferenceError(entry));
+    expect(context.get(entry, { or: 'fallback' })).toBe('fallback');
+  });
+  it('provides default value if there is no provider', () => {
+
+    const defaultValue = 'default';
+    const entryWithDefaults = { perContext: cxEvaluated<string>(() => null, { byDefault: () => defaultValue }) };
+
+    expect(context.get(entryWithDefaults)).toEqual(defaultValue);
+  });
+  it('provides evaluated value', () => {
+
+    const entry = {
+      perContext: cxEvaluated<string>(target => {
+
+        let value = '';
+
+        target.eachAsset(asset => {
+          value += asset;
+        });
+
+        return value;
+      }),
+    };
+
+    builder.provide(cxConstAsset(entry, 'a'));
+    builder.provide(cxConstAsset(entry, 'b'));
+    builder.provide(cxConstAsset(entry, 'c'));
+
+    expect(context.get(entry)).toBe('abc');
+  });
+});


### PR DESCRIPTION
- Pass the builder itself as second parameter to context creator
- Add support for `cxEvaluated()`
