### PR TITLE
Combining entries based on internal state

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "types": "./index.d.ts",
   "exports": "./dist/context-builder.js",
   "peerDependencies": {
-    "@proc7ts/context-values": "^7.0.0-dev.1",
+    "@proc7ts/context-values": "^7.0.0-dev.5",
     "@proc7ts/fun-events": "^10.5.0"
   },
   "dependencies": {
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^27.0.6",
-    "@proc7ts/context-values": "^7.0.0-dev.4",
+    "@proc7ts/context-values": "^7.0.0-dev.5",
     "@proc7ts/fun-events": "^10.5.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@run-z/eslint-config": "^1.3.0",

--- a/src/entries/dynamic.entry.spec.ts
+++ b/src/entries/dynamic.entry.spec.ts
@@ -1,16 +1,28 @@
-import { beforeEach, describe, expect, it } from '@jest/globals';
-import { cxDynamic, CxEntry, CxValues } from '@proc7ts/context-values';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { cxDynamic, CxEntry, CxReferenceError, CxValues } from '@proc7ts/context-values';
+import { noop } from '@proc7ts/primitives';
+import { Supply } from '@proc7ts/supply';
 import { cxBuildAsset, cxConstAsset } from '../assets';
 import { CxBuilder } from '../builder';
+import { CxSupply } from './supply';
 
 describe('cxDynamic', () => {
 
   let builder: CxBuilder;
   let context: CxValues;
+  let cxSupply: CxSupply;
 
   beforeEach(() => {
-    builder = new CxBuilder<CxValues>(get => ({ get }));
+    cxSupply = new Supply();
+    builder = new CxBuilder<CxValues>(get => ({ get, supply: cxSupply }));
     context = builder.context;
+  });
+
+  beforeEach(() => {
+    Supply.onUnexpectedAbort(noop);
+  });
+  afterEach(() => {
+    Supply.onUnexpectedAbort();
   });
 
   describe('array-valued', () => {
@@ -18,7 +30,7 @@ describe('cxDynamic', () => {
     let entry: CxEntry<readonly number[], number>;
 
     beforeEach(() => {
-      entry = { perContext: cxDynamic() };
+      entry = { perContext: cxDynamic(), toString: () => '[CxEntry test]' };
     });
 
     it('provides empty array initially', () => {
@@ -47,6 +59,31 @@ describe('cxDynamic', () => {
       supply.off();
 
       expect(context.get(entry)).toEqual([2]);
+    });
+    it('is unavailable if context disposed', () => {
+
+      const reason = new Error('Disposed');
+
+      cxSupply.off(reason);
+
+      expect(() => context.get(entry)).toThrow(new CxReferenceError(
+          entry,
+          'The [CxEntry test] is unavailable',
+          reason,
+      ));
+    });
+    it('becomes unavailable after context disposal', () => {
+      expect(context.get(entry)).toEqual([]);
+
+      const reason = new Error('Disposed');
+
+      cxSupply.off(reason);
+
+      expect(() => context.get(entry)).toThrow(new CxReferenceError(
+          entry,
+          'The [CxEntry test] is unavailable',
+          reason,
+      ));
     });
 
     describe('context derivation', () => {

--- a/src/entries/dynamic.entry.spec.ts
+++ b/src/entries/dynamic.entry.spec.ts
@@ -83,29 +83,16 @@ describe('cxDynamic', () => {
     });
   });
 
-  describe('with custom updater', () => {
+  describe('with internal state', () => {
 
     let entry: CxEntry<number, number>;
 
     beforeEach(() => {
       entry = {
-        perContext: cxDynamic({
-          createUpdater() {
-
-            let value = -1;
-
-            return {
-              get() {
-                return value;
-              },
-              set(assets) {
-                value = assets.reduce((prev, asset) => prev + asset, 0);
-              },
-              reset() {
-                value = 0;
-              },
-            };
-          },
+        perContext: cxDynamic<number, number, { sum: number }>({
+          create: assets => ({ sum: assets.reduce((prev, asset) => prev + asset, 0) }),
+          byDefault: () => ({ sum: 0 }),
+          access: get => () => get().sum,
         }),
       };
     });


### PR DESCRIPTION
- `cxRecent()` utilizes internal state
- `cxDynamic()` utilizes internal state
